### PR TITLE
Cluster ip example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tfplan.*
 *.tfstate
 *.tfstate.backup
 .DS_Store
+.terraform.tfstate.lock.info

--- a/examples/ingress_cluster_ip/ingress_cluster_example.md
+++ b/examples/ingress_cluster_ip/ingress_cluster_example.md
@@ -1,6 +1,17 @@
-http://gph.is/2cKlaPK
 
-#need to develop chart that will include ingress with all of the proper annotations
-#need a security group for the pods
-#will do a deployment and service using nginx, make sure the security group is passed at runtime
-#will also need a configmap to replace the nginx default.
+# ingress (cluster ip) example
+
+simple example highlighting the use of the aws ingress controller using cluster ip and pod security groups.
+
+# Steps
+1. Ensure that ```pod_sg_example``` is set to ```true```.  The default t3 instance class used in the other example node groups is not compatible.  Note that this example will use a m5.large instance with the associated additional costs.
+2. run: ```kubectl -n kube-system set env daemonset aws-node ENABLE_POD_ENI=true```
+ - this is needed to enable the networking requirements for pod security groups 
+3. ```helm install npc-ingress-test-cluster-ip ./examples/ingress_cluster_ip/ingress_cluster_ip_chart --set albSecurityGroup=$(terraform output --raw alb_security_group_id) --set podSecurityGroup=$(terraform output --raw pod_security_group_id)```
+4.  run: ```kubectl get ingress``
+ - note the ingress address, visit to confirm.
+
+
+# Cleanup
+1. ```helm uninstall npc-ingress-test-cluster-ip```
+  - very important that this is done before tearing down the lab.  since the ingress resource deployed as part of the chart will create alb, terraform has no way of knowing about it. executing a terraform destroy with removing this chart will hang the process, and you will need to remove some aws resources manually.

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/.helmignore
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/Chart.yaml
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: ingress-node-port-example
+name: ingress-cluster-ip-example
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/Chart.yaml
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ingress-node-port-example
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/templates/test-cluster-ip-ingress.yaml
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/templates/test-cluster-ip-ingress.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: confused-travolta
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: confused-travolta
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: confused-travolta
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: Always
+        name: confused-travolta
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: confused-travolta
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: confused-travolta
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-travolta
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/security-groups: {{.Values.albSecurityGroup}}
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: confused-travolta
+              servicePort: 80
+---
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: allow-alb-access
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: confused-travolta
+  securityGroups:
+    groupIds:
+      - {{.Values.podSecurityGroup}} 
+      #- ${POD_SG}

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/templates/test-cluster-ip-ingress.yaml
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/templates/test-cluster-ip-ingress.yaml
@@ -19,6 +19,15 @@ spec:
         name: confused-travolta
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: index
+          mountPath: /usr/share/nginx/html
+      nodeSelector:
+        type: chonky
+      volumes:
+      - name: index
+        configMap:
+          name: travolta
 ---
 apiVersion: v1
 kind: Service
@@ -61,5 +70,12 @@ spec:
       app.kubernetes.io/name: confused-travolta
   securityGroups:
     groupIds:
-      - {{.Values.podSecurityGroup}} 
-      #- ${POD_SG}
+      - {{.Values.podSecurityGroup}}
+---
+apiVersion: v1
+data:
+  index.html: |
+    <img src="https://media.giphy.com/media/hEc4k5pN17GZq/giphy.gif" alt="wat"  width="1000" />
+kind: ConfigMap
+metadata:
+  name: travolta

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/values.yaml
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/values.yaml
@@ -1,1 +1,2 @@
 albSecurityGroup: "placeholder"
+podSecurityGroup: "placeholder"

--- a/examples/ingress_cluster_ip/ingress_cluster_ip_chart/values.yaml
+++ b/examples/ingress_cluster_ip/ingress_cluster_ip_chart/values.yaml
@@ -1,0 +1,1 @@
+albSecurityGroup: "placeholder"

--- a/network/output.tf
+++ b/network/output.tf
@@ -3,7 +3,7 @@ output "eni_subnets" {
 }
 
 output "alb_sg" {
-    value = aws_security_group.eks_cluster_alb.id
+  value = aws_security_group.eks_cluster_alb.id
 }
 
 output "cluster_sg" {
@@ -12,6 +12,10 @@ output "cluster_sg" {
 
 output "node_sg" {
   value = aws_security_group.eks_nodes.id
+}
+
+output "pod_sg" {
+  value = aws_security_group.pod_security_group.id
 }
 
 output "public_subnets" {

--- a/network/security_group_rules.tf
+++ b/network/security_group_rules.tf
@@ -31,6 +31,26 @@ resource "aws_security_group_rule" "cluster_outbound" {
   type                     = "egress"
 }
 
+resource "aws_security_group_rule" "pod_outbound_cluster_comms" {
+  description              = "pods outbound"
+  from_port                = 53
+  protocol                 = "tcp"
+  security_group_id        = var.eks_generated_sg
+  source_security_group_id = aws_security_group.pod_security_group.id
+  to_port                  = 53
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "pod_outbound_cluster_comms_udp" {
+  description              = "pods outbound"
+  from_port                = 53
+  protocol                 = "udp"
+  security_group_id        = var.eks_generated_sg
+  source_security_group_id = aws_security_group.pod_security_group.id
+  to_port                  = 53
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "worker_node_outbound" {
   description       = "worker egress"
   from_port         = 0
@@ -82,7 +102,7 @@ resource "aws_security_group_rule" "nodes_egress_generated_sg" {
 }
 
 resource "aws_security_group_rule" "eks_alb_to_nodes" {
-    description              = "allow communication from alb to nodes in generated sg."
+  description              = "allow communication from alb to nodes in generated sg."
   from_port                = 30000
   protocol                 = -1
   security_group_id        = var.eks_generated_sg
@@ -93,12 +113,22 @@ resource "aws_security_group_rule" "eks_alb_to_nodes" {
 }
 
 resource "aws_security_group_rule" "eks_alb_to_custom_nodes" {
-    description              = "allow communication from alb to nodes in generated sg."
+  description              = "allow communication from alb to nodes in generated sg."
   from_port                = 30000
   protocol                 = -1
   security_group_id        = aws_security_group.eks_nodes.id
   source_security_group_id = aws_security_group.eks_cluster_alb.id
   to_port                  = 32767
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "eks_alb_pod_sg" {
+  description              = "allow communication from alb to nodes in generated sg."
+  from_port                = 80
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.pod_security_group.id
+  source_security_group_id = aws_security_group.eks_cluster_alb.id
+  to_port                  = 80
   type                     = "ingress"
 }
 

--- a/network/security_groups.tf
+++ b/network/security_groups.tf
@@ -32,5 +32,16 @@ resource "aws_security_group" "eks_cluster_alb" {
   }
 }
 
+#eks cluster alb security group
+resource "aws_security_group" "pod_security_group" {
+  name        = "eksPod_SG"
+  description = "security group for pods"
+  vpc_id      = aws_vpc.cluster_vpc.id
+
+  tags = {
+    Name = "${var.eks_cluster_name}-podd"
+  }
+}
+
 
 

--- a/network/variables.tf
+++ b/network/variables.tf
@@ -19,8 +19,8 @@ variable "eks_generated_sg" {
 }
 
 variable "external_ip" {
-    type = string
-    description = "ip range to allow access from for alb"
+  type        = string
+  description = "ip range to allow access from for alb"
 }
 
 variable "network_mask" {

--- a/output.tf
+++ b/output.tf
@@ -17,3 +17,7 @@ output "created_cluster_sg_from_module" {
 output "alb_security_group_id" {
   value = module.network.alb_sg
 }
+
+output "pod_security_group_id" {
+  value = module.network.pod_sg
+}

--- a/travolta.yaml
+++ b/travolta.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  index.html: |
+    <img src="https://media.giphy.com/media/hEc4k5pN17GZq/giphy.gif" alt="wat"  width="1000" />
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2021-06-07T15:41:34Z"
+  name: travolta
+  namespace: default
+  resourceVersion: "10595"
+  uid: b434d6e1-8b38-4d4b-a8fa-3795c582e752

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,11 @@ variable "network_mask" {
   default = 16
 }
 
+variable "pod_sg_example" {
+  type    = bool
+  default = false
+}
+
 variable "profile" {
   type        = string
   description = "aws profile to use"

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -138,6 +138,10 @@ resource "aws_eks_node_group" "chonky" {
   #instance_types  = var.instance_types
   instance_types = ["m5.large"]
 
+  labels = {
+    "type" = "chonky"
+  }
+
   scaling_config {
     desired_size = 1
     max_size     = 1

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -127,3 +127,37 @@ Content-Type: text/x-shellscript; charset="us-ascii"
     }
   }
 }
+
+resource "aws_eks_node_group" "chonky" {
+  count           = var.pod_sg_example ? 1 : 0
+  cluster_name    = aws_eks_cluster.test_cluster.name
+  version         = aws_eks_cluster.test_cluster.version
+  node_group_name = "${var.cluster_name}-node-group-chonky-${var.environment}"
+  node_role_arn   = aws_iam_role.eks_nodes.arn
+  subnet_ids      = module.network.private_subnets
+  #instance_types  = var.instance_types
+  instance_types = ["m5.large"]
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  lifecycle {
+    ignore_changes        = [scaling_config[0].desired_size]
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-node-group-chonky-${var.environment}"
+  }
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.aws_eks_worker_node_policy,
+    aws_iam_role_policy_attachment.aws_eks_cni_policy,
+    aws_iam_role_policy_attachment.ec2_read_only,
+    aws_eks_cluster.test_cluster
+  ]
+}


### PR DESCRIPTION
added an example using pod security groups and cluster ip service.  
- needs to use a larger instance type, node group using this is disabled by default
- deploys 5 replicas to the single node, ingress points at nginx containers serving Confused Travolta gif.

TODO:
- would be nice to set the ENI value on the daemonset at cluster launch, more reading needed.